### PR TITLE
Android support for content:// picked files

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.Abstractions/FileData.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Abstractions/FileData.cs
@@ -25,16 +25,28 @@ namespace Plugin.FilePicker.Abstractions
             _streamGetter = streamGetter;
         }
 
+        /// <summary>
+        /// Completely reads all bytes from the input stream and returns it as byte array. Can be
+        /// used when the returned file data consists of a stream, not a real filename.
+        /// </summary>
+        /// <param name="input">input stream</param>
+        /// <returns>byte array</returns>
+        public static byte[] ReadFully(Stream input)
+        {
+            using (var ms = new MemoryStream())
+            {
+                input.CopyTo(ms);
+                return ms.ToArray();
+            }
+        }
+
         public byte[] DataArray
         {
             get
             {
                 using (var stream = GetStream())
                 {
-                    var resultBytes = new byte[stream.Length];
-                    stream.Read(resultBytes, 0, (int)stream.Length);
-
-                    return resultBytes;
+                    return ReadFully(stream);
                 }
             }
         }
@@ -86,7 +98,7 @@ namespace Plugin.FilePicker.Abstractions
         /// <summary>
         /// Get stream if available
         /// </summary>
-        /// <returns></returns>
+        /// <returns>stream object</returns>
         public Stream GetStream()
         {
             if (_isDisposed)

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -50,9 +50,12 @@ namespace Plugin.FilePicker
                     var filePath = IOUtil.getPath (context, _uri);
 
                     if (string.IsNullOrEmpty (filePath))
-                        filePath = _uri.Path;
-
-                    var file = IOUtil.readFile (filePath);
+                        filePath = IOUtil.isMediaStore(_uri.Scheme) ? _uri.ToString() : _uri.Path;
+                    byte[] file;
+                    if (IOUtil.isMediaStore(_uri.Scheme))
+                        file = IOUtil.readFile(context, _uri);
+                    else
+                        file = IOUtil.readFile (filePath);
 
                     var fileName = GetFileName (context, _uri);
 

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
@@ -56,7 +56,14 @@ namespace Plugin.FilePicker
 
                     FilePickerActivity.FilePicked -= handler;
 
-                    tcs?.SetResult (new FileData (e.FilePath, e.FileName, () => System.IO.File.OpenRead (e.FilePath)));
+                    tcs?.SetResult (new FileData (e.FilePath, e.FileName,
+                        () =>
+                        {
+                            if (IOUtil.isMediaStore(e.FilePath))
+                                return new System.IO.MemoryStream(e.FileByte);
+                            else
+                                return System.IO.File.OpenRead (e.FilePath);
+                        }));
                 };
 
                 cancelledHandler = (s, e) => {

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
@@ -5,6 +5,7 @@ using Android.Provider;
 using Android.Database;
 using Java.IO;
 using Android.Webkit;
+using Plugin.FilePicker.Abstractions;
 
 namespace Plugin.FilePicker
 {
@@ -62,7 +63,7 @@ namespace Plugin.FilePicker
                 }
             }
             // MediaStore (and general)
-            else if ("content".Equals (uri.Scheme, StringComparison.OrdinalIgnoreCase)) {
+            if (isMediaStore(uri.Scheme)) {
                 return getDataColumn (context, uri, null, null);
             }
             // File
@@ -73,15 +74,23 @@ namespace Plugin.FilePicker
             return null;
         }
 
+        /// <summary>
+        /// Checks if the scheme part of the URL matches the content:// scheme
+        /// </summary>
+        /// <param name="scheme">scheme part of URL</param>
+        /// <returns>true when it matches, false when not</returns>
+        public static bool isMediaStore(string scheme)
+        {
+            return scheme.StartsWith("content");
+        }
+
         public static string getDataColumn (Context context, Android.Net.Uri uri, string selection,
         string [] selectionArgs)
         {
 
             ICursor cursor = null;
-            var column = "_data";
-            string [] projection = {
-                column
-            };
+            string column = MediaStore.Files.FileColumns.Data;
+            string [] projection = { column };
 
             try {
                 cursor = context.ContentResolver.Query (uri, projection, selection, selectionArgs,
@@ -122,6 +131,12 @@ namespace Plugin.FilePicker
         public static bool isMediaDocument (Android.Net.Uri uri)
         {
             return "com.android.providers.media.documents".Equals (uri.Authority);
+        }
+
+        public static Byte[] readFile(Context context, Android.Net.Uri uri)
+        {
+            using (var inStream = context.ContentResolver.OpenInputStream(uri))
+                return FileData.ReadFully(inStream);
         }
 
         public static byte [] readFile (string file)


### PR DESCRIPTION
This pull request adds support for the content:// URL scheme under Android. I checked the changes from pull request #8 and applied them to the latest develop branch, and I also compared it to ArtjomP's fork of the FilePicker plugin. Additionally I updated the sample project and tested it with the Forms sample under Android: Picking an image file that is stored in the OneDrive part of the file system is correctly picked and shown in the sample app.