### PR TITLE
Fix UWP UnauthorizedExceptions

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.UWP/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.UWP/FilePickerImplementation.cs
@@ -27,7 +27,7 @@ namespace Plugin.FilePicker
                 return null;
 
             StorageApplicationPermissions.FutureAccessList.Add(file);
-            return new FileData(file.Path, file.Name, () => File.OpenRead(file.Path));
+            return new FileData(file.Path, file.Name, () => file.OpenStreamForReadAsync().Result);
         }
 
         public async Task<bool> SaveFile(FileData fileToSave)


### PR DESCRIPTION
Trying to use this in UWP currently throws an UnauthorizedAccessException, as trying to read a StorageFile directly via its filepath isn't allowed. Instead, you have to get the stream from the StorageFile itself.