### PR TITLE
fixed picking files from OneDrive

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
@@ -96,7 +96,9 @@ namespace Plugin.FilePicker
                 cursor = context.ContentResolver.Query (uri, projection, selection, selectionArgs,
                         null);
                 if (cursor != null && cursor.MoveToFirst ()) {
-                    int column_index = cursor.GetColumnIndexOrThrow (column);
+                    int column_index = cursor.GetColumnIndex(column);
+                    if (column_index == -1)
+                        return null;
                     return cursor.GetString (column_index);
                 }
             } finally {


### PR DESCRIPTION
Picking files from OneDrive folder is now fixed. This is the follow-up PR from #22 (it seems closed PR's can't be reopened, so I made another one). This should also fix #42, maybe #41 and makes PR #8 obsolete.