### PR TITLE
Android: Fixed picking files from download folder

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
@@ -34,6 +34,13 @@ namespace Plugin.FilePicker
                 else if (isDownloadsDocument (uri)) {
 
                     string id = DocumentsContract.GetDocumentId (uri);
+
+                    if (!string.IsNullOrEmpty(id) &&
+                        id.StartsWith("raw:"))
+                    {
+                        return id.Substring(4);
+                    }
+
                     Android.Net.Uri contentUri = ContentUris.WithAppendedId (
                             Android.Net.Uri.Parse ("content://downloads/public_downloads"), long.Parse (id));
 


### PR DESCRIPTION
Here's another fix for Android:

> fixed picking files from the download folder; on newer devices the document ID may not be a number, but the real filename prefixed with "raw:"

I took the fix from this pull request: https://github.com/iPaulPro/aFileChooser/pull/96 - the whole Android implementation seems to be based on this project.

I also tested all other variants of sources where files can be picked from, and all work on my Android 8.1 device.