### PR TITLE
Sample: Fixed crash when user doesn't select a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ Add this as a source to your IDE to find the latest packages: [https://ci.appvey
 
 Call **CrossFilePicker.Current** from any platform or .NET Standard project to gain access to APIs.
 
+### Example
+
+            try
+            {
+                FileData fileData = await CrossFilePicker.Current.PickFile();
+                if (fileData == null)
+                    return; // user canceled file picking
+
+                string fileName = fileData.FileName;
+                string contents = System.Text.Encoding.UTF8.GetString(fileData.DataArray);
+
+                System.Console.WriteLine("File name chosen: " + fileName);
+                System.Console.WriteLine("File data: " + contents);
+            }
+            catch (Exception ex)
+            {
+                System.Console.WriteLine("Exception choosing file: " + ex.ToString());
+            }
+
 ### **IMPORTANT**
 **Android:**
 The `WRITE_EXTERNAL_STORAGE` & `READ_EXTERNAL_STORAGE` permissions are required.

--- a/samples/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.FormsPage.xaml.cs
+++ b/samples/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.FormsPage.xaml.cs
@@ -21,6 +21,11 @@ namespace Plugin.FilePicker.Sample.Forms
 
             var pickedFile = await CrossFilePicker.Current.PickFile();
 
+            if (pickedFile == null)
+            {
+                return;
+            }
+
             FileNameLabel.Text = pickedFile.FileName;
             FilePathLabel.Text = pickedFile.FilePath;
 


### PR DESCRIPTION
Here's a fix for the sample project:

> fixes crash in Xamarin.Forms sample when user doesn't select file; also added example code in README file

Using this code in user projects should also fix #31.