### PR TITLE
fix android mime types implementation

### DIFF
--- a/samples/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.FormsPage.xaml.cs
+++ b/samples/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.Forms/Plugin.FilePicker.Sample.FormsPage.xaml.cs
@@ -12,7 +12,14 @@ namespace Plugin.FilePicker.Sample.Forms
 
         private async void Handle_Clicked(object sender, EventArgs args)
         {
-            var pickedFile = await CrossFilePicker.Current.PickFile();
+
+            string[] allowedTypes = null;
+
+            if (Device.RuntimePlatform == Device.Android) {
+                allowedTypes = new string[] { "image/png", "image/jpeg" };
+            }
+
+            var pickedFile = await CrossFilePicker.Current.PickFile(allowedTypes);
 
             if (pickedFile != null)
             {

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Plugin.FilePicker.Abstractions;
 using Android.Provider;
 using System.Net;
+using System.Linq;
 
 namespace Plugin.FilePicker
 {
@@ -22,34 +23,14 @@ namespace Plugin.FilePicker
 
             context = Application.Context;
 
-            string[] allowedTypes = Intent.GetStringArrayExtra("allowedTypes") ?? null;
+            string[] allowedTypes = Intent.GetStringArrayExtra("allowedTypes")?.Where(o => !string.IsNullOrEmpty(o) && o.Contains("/")).ToArray();
 
             var intent = new Intent (Intent.ActionGetContent);
 
-            if (allowedTypes != null)
-            {
-                var typeString = "";
-                for (var i = 0; i < allowedTypes.Length; i++)
-                {
-                    if (allowedTypes[i].Contains("/"))
-                    {
-                        typeString += allowedTypes[i];
+            intent.SetType("*/*");
 
-                        if (i != allowedTypes.Length - 1)
-                        {
-                            typeString += "|";
-                        }
-                    }
-                }
-                if (string.IsNullOrWhiteSpace(typeString))
-                {
-                    typeString = "*/*";
-                }
-                intent.SetType(typeString);
-            }
-            else
-            {
-                intent.SetType("*/*");
+            if (allowedTypes != null && allowedTypes.Any()) {
+                intent.PutExtra(Intent.ExtraMimeTypes, allowedTypes);
             }
 
             intent.AddCategory (Intent.CategoryOpenable);


### PR DESCRIPTION
Hello,
I think current implementation of file type specification is broken on Android when specifying multiple file types. For instance:
`new string[] { "image/png" } // it's working`
`new string[] { "image/jpeg" } // it's working`
`new string[] { "image/png", "image/jpeg" } // not working`

When I try to specify multiple file types, I cannot pick none file at all. I tried to dig a little deeper and I found that now is called something like this:
`intent.setType("image/png|image/jpeg")`

But the right solution is like this (according for example this [https://medium.com/@louis993546/how-to-ask-system-to-open-intent-to-select-jpg-and-png-only-on-android-i-e-no-gif-e0491af240bf](https://medium.com/@louis993546/how-to-ask-system-to-open-intent-to-select-jpg-and-png-only-on-android-i-e-no-gif-e0491af240bf)):
`intent.PutExtra(Intent.ExtraMimeTypes, new string[] { "image/png", "image/jpeg" });`

So I've changed it, tested it on some Android devices and created this PR 😄 