### PR TITLE
Android: return from task with Exception that was thrown during file picking

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.Abstractions/FilePickerCancelledEventArgs.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Abstractions/FilePickerCancelledEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Plugin.FilePicker.Abstractions
+{
+    /// <summary>
+    /// Event arguments for the event when file picking was cancelled, either
+    /// by the user or when an exception occured
+    /// </summary>
+    public class FilePickerCancelledEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Exception that occured that led to cancelling file picking; may be
+        /// null when file picking was cancelled by the user
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -87,9 +87,14 @@ namespace Plugin.FilePicker
 
                     OnFilePicked (new FilePickerEventArgs (file, fileName, filePath));
                 } catch (Exception readEx) {
+                    System.Diagnostics.Debug.Write(readEx);
                     // Notify user file picking failed.
-                    OnFilePickCancelled ();
-                    System.Diagnostics.Debug.Write (readEx);
+                    FilePickCancelled?.Invoke(
+                        this,
+                        new FilePickerCancelledEventArgs
+                        {
+                            Exception = readEx
+                        });
                 } finally {
                     Finish ();
                 }
@@ -122,7 +127,7 @@ namespace Plugin.FilePicker
         }
 
         internal static event EventHandler<FilePickerEventArgs> FilePicked;
-        internal static event EventHandler<EventArgs> FilePickCancelled;
+        internal static event EventHandler<FilePickerCancelledEventArgs> FilePickCancelled;
 
         private static void OnFilePickCancelled ()
         {

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
@@ -91,6 +91,7 @@ namespace Plugin.FilePicker
                 FilePickerActivity.FilePicked += handler;
             } catch (Exception exAct) {
                 Debug.Write (exAct);
+                _completionSource.SetException(exAct);
             }
 
             return _completionSource.Task;

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
@@ -53,11 +53,12 @@ namespace Plugin.FilePicker
                 this._context.StartActivity (pickerIntent);
 
                 EventHandler<FilePickerEventArgs> handler = null;
-                EventHandler<EventArgs> cancelledHandler = null;
+                EventHandler<FilePickerCancelledEventArgs> cancelledHandler = null;
 
                 handler = (s, e) => {
                     var tcs = Interlocked.Exchange (ref _completionSource, null);
 
+                    FilePickerActivity.FilePickCancelled -= cancelledHandler;
                     FilePickerActivity.FilePicked -= handler;
 
                     tcs?.SetResult (new FileData (e.FilePath, e.FileName,
@@ -74,8 +75,16 @@ namespace Plugin.FilePicker
                     var tcs = Interlocked.Exchange (ref _completionSource, null);
 
                     FilePickerActivity.FilePickCancelled -= cancelledHandler;
+                    FilePickerActivity.FilePicked -= handler;
 
-                    tcs?.SetResult (null);
+                    if (e?.Exception != null)
+                    {
+                        tcs?.SetException(e.Exception);
+                    }
+                    else
+                    {
+                        tcs?.SetResult (null);
+                    }
                 };
 
                 FilePickerActivity.FilePickCancelled += cancelledHandler;


### PR DESCRIPTION
This PR passes any Exception during file picking to the user; the sample code in README.md documents this. Before that, the caller only got a null FileData object without knowing what happened; now the proper exception is thrown. Most of the time, the problem is that the user didn't add the proper permissions or didn't ask the user for the permission (e.g. Android 6.0). Now the error is transparent to the user.