### PR TITLE
iOS: Use correct view controller to present document picker

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
@@ -136,8 +136,8 @@ namespace Plugin.FilePicker
             documentPicker.WasCancelled += DocumentPicker_WasCancelled;
             documentPicker.DidPickDocumentAtUrls += DocumentPicker_DidPickDocumentAtUrls;
 
-            var rootViewController = UIApplication.SharedApplication.KeyWindow.RootViewController;
-            rootViewController.PresentViewController(documentPicker, true, null);
+            UIViewController viewController = GetActiveViewController();
+            viewController.PresentViewController(documentPicker, true, null);
 
             Handler = null;
 
@@ -152,6 +152,23 @@ namespace Plugin.FilePicker
             };
 
             return _completionSource.Task;
+        }
+
+        /// <summary>
+        /// Finds active view controller to use to present document picker
+        /// </summary>
+        /// <returns>view controller to use</returns>
+        private static UIViewController GetActiveViewController()
+        {
+            UIWindow window = UIApplication.SharedApplication.KeyWindow;
+            UIViewController viewController = window.RootViewController;
+
+            while (viewController.PresentedViewController != null)
+            {
+                viewController = viewController.PresentedViewController;
+            }
+
+            return viewController;
         }
 
         private int GetRequestId ()


### PR DESCRIPTION
This PR implements the suggestions from issues #58 and #21. The root view controller is searched for the currently presented view controller. I can test this on real iOS devices as soon as the PR is merged.