### PR TITLE
Android fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Call **CrossFilePicker.Current** from any platform or .NET Standard project to g
 **Android:**
 The `WRITE_EXTERNAL_STORAGE` & `READ_EXTERNAL_STORAGE` permissions are required.
 
+Starting from Android 6.0 (Marshmallow) you have to request the permission from the user. This can
+be done using `ActivityCompat.RequestPermission()` or you can use the
+[Xamarin.Plugin.Permission](https://github.com/jamesmontemagno/PermissionsPlugin) plugin. See
+also code in the sample project:
+https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows/blob/develop/samples/Plugin.FilePicker.Sample.Forms/Forms/MainPage.xaml.cs
+
 **iOS:** 
 Need [Configure iCloud Driver for your app](https://developer.xamarin.com/guides/ios/platform_features/intro_to_cloudkit)
 
@@ -80,6 +86,13 @@ This occurs when you are using the old-style NuGet references (not the PackageRe
 and you forgot to add the NuGet package to the Android package. When using PackageReference this
 is not necessary anymore because the bait-and-switch assemblies of FilePicker are correctly
 resolved.
+
+**InvalidOperationException "Android permission READ_EXTERNAL_STORAGE is missing or was denied by user"**
+
+Starting from Android 6.0 (Marshmallow) permissions must be added to the AndroidManifest.xml (as
+before) but the permission must be requested and granted by the user at runtime as well. When
+the user denied the permission, don't call PickFile(). Check out the sample project in the github
+repository for an example how to check for permission.
 
 ## Contributors
 * [jfversluis](https://github.com/jfversluis)

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Plugin.FilePicker.Abstractions;
 using Android.Provider;
 using System.Net;
+using System.Linq;
 
 namespace Plugin.FilePicker
 {
@@ -22,34 +23,15 @@ namespace Plugin.FilePicker
 
             context = Application.Context;
 
-            string[] allowedTypes = Intent.GetStringArrayExtra("allowedTypes") ?? null;
-
             var intent = new Intent (Intent.ActionGetContent);
 
-            if (allowedTypes != null)
-            {
-                var typeString = "";
-                for (var i = 0; i < allowedTypes.Length; i++)
-                {
-                    if (allowedTypes[i].Contains("/"))
-                    {
-                        typeString += allowedTypes[i];
+            intent.SetType("*/*");
 
-                        if (i != allowedTypes.Length - 1)
-                        {
-                            typeString += "|";
-                        }
-                    }
-                }
-                if (string.IsNullOrWhiteSpace(typeString))
-                {
-                    typeString = "*/*";
-                }
-                intent.SetType(typeString);
-            }
-            else
-            {
-                intent.SetType("*/*");
+            string[] allowedTypes = Intent.GetStringArrayExtra("allowedTypes")?.
+                Where(o => !string.IsNullOrEmpty(o) && o.Contains("/")).ToArray();
+
+            if (allowedTypes != null && allowedTypes.Any()) {
+                intent.PutExtra(Intent.ExtraMimeTypes, allowedTypes);
             }
 
             intent.AddCategory (Intent.CategoryOpenable);

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
@@ -37,6 +37,13 @@ namespace Plugin.FilePicker
         //private Task<FileData> TakeMediaAsync (string type, string action)
         private Task<FileData> TakeMediaAsync(string[] allowedTypes, string action)
         {
+            if (this._context.PackageManager.CheckPermission(
+                Android.Manifest.Permission.ReadExternalStorage,
+                this._context.PackageName) == Android.Content.PM.Permission.Denied)
+            {
+                throw new InvalidOperationException("Android permission READ_EXTERNAL_STORAGE is missing or was denied by user");
+            }
+
             var id = GetRequestId ();
 
             var ntcs = new TaskCompletionSource<FileData> (id);

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/IOUtil.cs
@@ -41,10 +41,30 @@ namespace Plugin.FilePicker
                         return id.Substring(4);
                     }
 
-                    Android.Net.Uri contentUri = ContentUris.WithAppendedId (
-                            Android.Net.Uri.Parse ("content://downloads/public_downloads"), long.Parse (id));
+                    string[] contentUriPrefixesToTry = new string[]
+                    {
+                        "content://downloads/public_downloads",
+                        "content://downloads/my_downloads"
+                    };
 
-                    return getDataColumn (context, contentUri, null, null);
+                    foreach (string contentUriPrefix in contentUriPrefixesToTry)
+                    {
+                        Android.Net.Uri contentUri = ContentUris.WithAppendedId(
+                            Android.Net.Uri.Parse(contentUriPrefix), long.Parse(id));
+
+                        try
+                        {
+                            var path = getDataColumn(context, contentUri, null, null);
+                            if (path != null)
+                            {
+                                return path;
+                            }
+                        }
+                        catch (Exception)
+                        {
+                            // ignore exception; path can't be retrieved using ContentResolver
+                        }
+                    }
                 }
                 // MediaProvider
                 else if (isMediaDocument (uri)) {


### PR DESCRIPTION
I made some fixes for the Android part of the plugin:

* The plugin now checks if the permission READ_EXTERNAL_STORAGE is granted. In most cases the user will stumble over not having this permission after picking when trying to read the picked file. I also added an explanation to the README.md file. This fixes #89.

* Fix for the Android mime types selection, cherry picked from #85.

* Fix when picking a downloaded file. The Android DownloadManager won't return an actual file path; downloaded files can only be resolved using ContentResolver fixes #86.