### PR TITLE
iOS fixes

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
@@ -59,18 +59,9 @@ namespace Plugin.FilePicker
                 e.Url.StopAccessingSecurityScopedResource();
 
                 // iCloud drive can return null for LocalizedName.
-                if (filename == null)
+                if (filename == null && pathname != null)
                 {
-                    // Retrieve actual filename by taking the last entry after / in FileURL.
-                    // e.g. /path/to/file.ext -> file.ext
-
-                    // filesplit is either:
-                    // 0 (pathname is null, or last / is at position 0)
-                    // -1 (no / in pathname)
-                    // positive int (last occurence of / in string)
-                    var filesplit = pathname?.LastIndexOf ('/') ?? 0;
-
-                    filename = pathname?.Substring (filesplit + 1);
+                    filename = Path.GetFileName(pathname);
                 }
 
                 OnFilePicked(new FilePickerEventArgs(dataBytes, filename, pathname));

--- a/src/Plugin.FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.iOS/FilePickerImplementation.cs
@@ -54,7 +54,7 @@ namespace Plugin.FilePicker
                 System.Runtime.InteropServices.Marshal.Copy (data.Bytes, dataBytes, 0, Convert.ToInt32 (data.Length));
 
                 string filename = doc.LocalizedName;
-                string pathname = doc.FileUrl?.ToString();
+                string pathname = doc.FileUrl?.Path;
 
                 e.Url.StopAccessingSecurityScopedResource();
 


### PR DESCRIPTION
This PR contains fixes for iOS, tested on an actual iOS 11 device. Fixes path name handling bug that was introduced by the "file types" PR from #26 and PR #54 that was reverted by #65. This time it works[tm]!