### PR TITLE
Request Android Storage permission automatically when they aren't available

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -7,6 +7,8 @@ using Plugin.FilePicker.Abstractions;
 using System;
 using System.Linq;
 using System.Net;
+using Android;
+using Android.Content.PM;
 
 namespace Plugin.FilePicker
 {
@@ -22,6 +24,8 @@ namespace Plugin.FilePicker
         /// Intent Extra constant to pass list of allowed types to FilePicker activity.
         /// </summary>
         public const string ExtraAllowedTypes = "EXTRA_ALLOWED_TYPES";
+        private const int REQUEST_STORAGE = 1;
+
 
         /// <summary>
         /// Android context to be used for opening file picker
@@ -40,10 +44,10 @@ namespace Plugin.FilePicker
             this.context = Application.Context;
 
             if (this.context.PackageManager.CheckPermission(
-                Android.Manifest.Permission.ReadExternalStorage,
-                this.context.PackageName) == Android.Content.PM.Permission.Granted)
+                Manifest.Permission.ReadExternalStorage,
+                this.context.PackageName) == Permission.Granted)
             {
-                if ((int)Build.VERSION.SDK_INT >= 23)
+                if ((int)Build.VERSION.SdkInt >= 23)
                 {
                     RequestPermissions(new String[] { Manifest.Permission.ReadExternalStorage }, REQUEST_STORAGE);
                 }
@@ -53,7 +57,7 @@ namespace Plugin.FilePicker
                 }
             }
             else
-            {
+            { 
                 StartPicker();
             }
         }
@@ -62,7 +66,7 @@ namespace Plugin.FilePicker
         /// Receives the answer from the dialog that asks for the READ_EXTERNAL_STORAGE permission and starts 
         /// the FilePicker if it's granted or otherwise closes this activity.
         /// </summary>
-        /// <param name="requestCode">saved instance state; contains the type of request that gets received</param>
+        /// <param name="requestCode">requestCode; shows us that the dialog we requested is responsible for this answer</param>
         /// <param name="permissions">permissions; unused</param>
         /// <param name="grantResults">grantResults; contains the result of the dialog to request the permission</param>
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -47,18 +47,18 @@ namespace Plugin.FilePicker
                 Manifest.Permission.ReadExternalStorage,
                 this.context.PackageName) == Permission.Granted)
             {
+                StartPicker();
+            }
+            else
+            {
                 if ((int)Build.VERSION.SdkInt >= 23)
                 {
                     RequestPermissions(new String[] { Manifest.Permission.ReadExternalStorage }, REQUEST_STORAGE);
                 }
                 else
                 {
-                    throw new InvalidOperationException("Android permission READ_EXTERNAL_STORAGE is missing");
+                    throw new InvalidOperationException("Android permission READ_EXTERNAL_STORAGE is missing and API level lower then 23, so it can't be requested");
                 }
-            }
-            else
-            { 
-                StartPicker();
             }
         }
 

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -28,7 +28,7 @@ namespace Plugin.FilePicker
         /// This variable gets passed when the request for the permission to access storage 
         /// gets send and then gets again read whne the request gets answered.
         /// </summary>
-        private const int REQUEST_STORAGE = 1;
+        private const int RequestStorage = 1;
 
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Plugin.FilePicker
             {
                 if ((int)Build.VERSION.SdkInt >= 23)
                 {
-                    RequestPermissions(new String[] { Manifest.Permission.ReadExternalStorage }, REQUEST_STORAGE);
+                    RequestPermissions(new String[] { Manifest.Permission.ReadExternalStorage }, RequestStorage);
                 }
                 else
                 {
@@ -75,7 +75,7 @@ namespace Plugin.FilePicker
         /// <param name="grantResults">grantResults; contains the result of the dialog to request the permission</param>
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
         {
-            if (requestCode == REQUEST_STORAGE)
+            if (requestCode == RequestStorage)
             {
                 if (grantResults[0] == Permission.Granted)
                 {

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerActivity.cs
@@ -24,6 +24,10 @@ namespace Plugin.FilePicker
         /// Intent Extra constant to pass list of allowed types to FilePicker activity.
         /// </summary>
         public const string ExtraAllowedTypes = "EXTRA_ALLOWED_TYPES";
+        /// <summary>
+        /// This variable gets passed when the request for the permission to access storage 
+        /// gets send and then gets again read whne the request gets answered.
+        /// </summary>
         private const int REQUEST_STORAGE = 1;
 
 

--- a/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.Android/FilePickerImplementation.cs
@@ -66,13 +66,6 @@ namespace Plugin.FilePicker
         /// <returns>picked file data, or null when picking was cancelled</returns>
         private Task<FileData> PickFileAsync(string[] allowedTypes, string action)
         {
-            if (this.context.PackageManager.CheckPermission(
-                Android.Manifest.Permission.ReadExternalStorage,
-                this.context.PackageName) == Android.Content.PM.Permission.Denied)
-            {
-                throw new InvalidOperationException("Android permission READ_EXTERNAL_STORAGE is missing or was denied by user");
-            }
-
             var id = this.GetRequestId();
 
             var ntcs = new TaskCompletionSource<FileData>(id);


### PR DESCRIPTION
### Description of Change ###

When the permissions aren't available in Android API level >=23 they app now asks the user to grant the permission instead of throwing an error. 


### Platforms Affected ### 
- Android
