### PR TITLE
Support for SourceLink

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.csproj
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.csproj
@@ -46,6 +46,15 @@
     <Authors>Gerald Versluis, rafaelrmou, vividos</Authors>
     <Copyright>Copyright 2017-2018 FilePicker team</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Include the PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
@@ -84,5 +93,9 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net45')) ">
     <Compile Include="**\*.net45.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

This PR adds support for SourceLink, as described on https://www.meziantou.net/2018/07/09/how-to-debug-nuget-packages-using-sourcelink

### Issues Resolved ### 

None.

### Platforms Affected ### 

All.