### PR TITLE
Fixed using NuGet package under WPF

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.csproj
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <!--Work around so the conditions work below-->
     <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20;net45;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20;net45</TargetFrameworks>
     <AssemblyName>Plugin.FilePicker</AssemblyName>
     <RootNamespace>Plugin.FilePicker</RootNamespace>
     <PackageId>Xamarin.Plugin.FilePicker</PackageId>
@@ -93,6 +93,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net45')) ">
     <Compile Include="**\*.net45.cs" />
+    <Reference Include="PresentationFramework" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
... by actually compiling the FilePicker plugin for .NET 4.5 and higher (#122).

### Description of Change ###

.NET 45 target is now compiled when creating NuGet package

### Issues Resolved ### 

- fixes #122

### Platforms Affected ### 

- WPF
