### PR TITLE
Build FilePicker plugin for multiple MonoAndroid targets

### DIFF
--- a/src/Plugin.FilePicker/Plugin.FilePicker.csproj
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <!--Work around so the conditions work below-->
     <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20;net45;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid90;Xamarin.Mac20;net45</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80;MonoAndroid81;MonoAndroid90;Xamarin.Mac20;net45;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80;MonoAndroid81;MonoAndroid90;Xamarin.Mac20;net45</TargetFrameworks>
     <AssemblyName>Plugin.FilePicker</AssemblyName>
     <RootNamespace>Plugin.FilePicker</RootNamespace>
     <PackageId>Xamarin.Plugin.FilePicker</PackageId>


### PR DESCRIPTION
### Description of Change ###

Commit text: added targets MonoAndroid80 and MonoAndroid81 in order to have more matching variants when compiling against apps with various target framework versions

Basically does what it says. The build for targets where the Android SDK is not installed may fail - Azure and AppVeyor build servers have all SDKs installed, though. This should get rid of the warning about TargetFrameworkVersion too low during an app build.

### Issues Resolved ### 

- fixes #123

### Platforms Affected ### 

- Android