### PR TITLE
Fixed error "Only one operation can be active at a time"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Starts file picking and returns file data for picked file. File types can be
 specified in order to limit files that can be selected. Note that this method
 may throw exceptions that occured during file picking.
 
+Note that on Android it can happen that PickFile() can be called twice. In
+this case the first PickFile() call will return null as it is effectively
+cancelled.
+
 Parameter `allowedTypes`:
 Specifies one or multiple allowed types. When null, all file types can be
 selected while picking.

--- a/src/Plugin.FilePicker/Android/FilePickerImplementation.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerImplementation.android.cs
@@ -72,12 +72,13 @@ namespace Plugin.FilePicker
         {
             var id = this.GetRequestId();
 
-            var ntcs = new TaskCompletionSource<FileData>(id);
-
-            if (Interlocked.CompareExchange(ref this.completionSource, ntcs, null) != null)
+            var previousTcs = Interlocked.Exchange(ref this.completionSource, null);
+            if (previousTcs != null)
             {
-                throw new InvalidOperationException("Only one operation can be active at a time");
+                previousTcs.TrySetResult(null);
             }
+
+            var ntcs = new TaskCompletionSource<FileData>(id);
 
             try
             {


### PR DESCRIPTION
fixed error "Only one operation can be active at a time" when calling PickFile() twice; this can happen when an Android activity is restarted, e.g. using OnNewIntent.; the first PickFile() call then returns null (#131)

### Description of Change ###

On Android, the exception is not thrown anymore; instead the previous task result is set to null, in order to notify the user about the cancelled picking. While it might be better to cancel the task, this is the more compatible change; most users will check for null from `PickFile()`, but not for `TaskCanceledException `specifically. In my Xamarin.Essentials PR this is solved by cancelling the task.

### Issues Resolved ### 

- fixes #131

### Platforms Affected ### 

Only Android. The code for throwing the exception is also in iOS, but I don't see a way on iOS to call PickFile() twice.
