### PR TITLE
fixed NullReferenceException thrown by PickFile()

### DIFF
--- a/src/Plugin.FilePicker/Android/FilePickerImplementation.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerImplementation.android.cs
@@ -72,13 +72,13 @@ namespace Plugin.FilePicker
         {
             var id = this.GetRequestId();
 
-            var previousTcs = Interlocked.Exchange(ref this.completionSource, null);
+            var ntcs = new TaskCompletionSource<FileData>(id);
+
+            var previousTcs = Interlocked.Exchange(ref this.completionSource, ntcs);
             if (previousTcs != null)
             {
                 previousTcs.TrySetResult(null);
             }
-
-            var ntcs = new TaskCompletionSource<FileData>(id);
 
             try
             {


### PR DESCRIPTION
### Description of Change ###

The last PR #133 had an error, so that on Android the file picker shows, but the task also throws a NullReferenceException.  I guess we need another beta version. Sorry!

### Issues Resolved ### 

- fixes #133, #131 

### Platforms Affected ### 

- Android
