### PR TITLE
doc changes for 2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## Version 2.1.xx
+## Version 2.1.18
 
-No code changes from the version 2.1.12-beta.
+Release version. No code changes since the version 2.1.17-beta.
+
+## Version 2.1.17-beta
+
+Android: Fixed NullReferenceException caused by the bugfix from version 2.1.16-beta.
+
+## Version 2.1.16-beta
+
+Android: Fixed error "Only one operation can be active at a time" when re-entering PickFile()
+call; now the first call returns null (#131).
 
 ## Version 2.1.12-beta
 

--- a/src/Plugin.FilePicker/Plugin.FilePicker.csproj
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.csproj
@@ -40,7 +40,7 @@
 
     <Title>FilePicker Plugin for Xamarin, Windows and Mac</Title>
     <Summary>Simple cross-platform plug-in that allows you to pick files and work with them. View full project page for README</Summary>
-    <Description>Simple cross-platform plug-in that allows you to pick files and work with them. Version 2.1 supports .NET Standard and Visual Studio 2017. Supported platforms are Xamarin.Android, Xamarin.iOS, Xamarin.Mac, Xamarin.Forms, UWP and WPF.</Description>
+    <Description>Simple cross-platform plug-in that allows you to pick files and work with them. Version 2.1 supports .NET Standard and Visual Studio 2017 and 2019. Supported platforms are Xamarin.Android, Xamarin.iOS, Xamarin.Mac, Xamarin.Forms, UWP and WPF.</Description>
 
     <Owners>Gerald Versluis</Owners>
     <Authors>Gerald Versluis, rafaelrmou, vividos</Authors>


### PR DESCRIPTION
### Description of Change ###

We have the 2.0.x plugin on NuGet for about 7 months, and all issues reported since then are resolved, so I think we should do a non-beta 2.1 release. In this PR I updated the changelog and the NuGet package data for a 2.1 release.
@jfversluis  You may have to adjust the final version number afterwards, the version number 2.1.18 was just my guess and depends on if the beta build automatically increments the version number.

### Issues Resolved ### 

none

### Platforms Affected ### 

all