### PR TITLE
NRE as since 2.1.xx the plugin is released to NuGet in Debug configuration

### DIFF
--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -141,8 +141,8 @@ namespace Plugin.FilePicker
             {
                 try
                 {
-                    if(data == null)
-                        throw new Exception("File URI is not available");
+                    if (data?.Data == null)
+                        throw new Exception("File picking returned no valid data");
 
                     System.Diagnostics.Debug.Write(data.Data);
 

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -139,9 +139,10 @@ namespace Plugin.FilePicker
             }
             else
             {
-                System.Diagnostics.Debug.Write(data.Data);
                 try
                 {
+	                System.Diagnostics.Debug.Write(data.Data);
+
                     var uri = data.Data;
 
                     var filePath = IOUtil.GetPath(this.context, uri);

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -141,7 +141,10 @@ namespace Plugin.FilePicker
             {
                 try
                 {
-	                System.Diagnostics.Debug.Write(data.Data);
+                    if(data == null)
+                        throw new Exception("File URI is not available");
+
+                    System.Diagnostics.Debug.Write(data.Data);
 
                     var uri = data.Data;
 


### PR DESCRIPTION
As since 2.1.xx the plugin is released to NuGet in Debug configuration (surprisingly enough) this line causes NRE for some Android versions #143

### Description of Change ###

Moved Debug.Write into try/catch block to fix NRE crash when "data" is null. 

### Issues Resolved ### 
- fixed NRE on some Android devices

### Platforms Affected ### 
- Android