### PR TITLE
Add a GetStream Method to the API

### DIFF
--- a/src/Plugin.FilePicker/FilePickerImplementation.ios.cs
+++ b/src/Plugin.FilePicker/FilePickerImplementation.ios.cs
@@ -169,10 +169,7 @@ namespace Plugin.FilePicker
                 tcs?.SetResult(new FileData(
                     args.FilePath,
                     args.FileName,
-                    () =>
-                    {
-                        return new FileStream(args.FilePath, FileMode.Open, FileAccess.Read);
-                    }));
+                    () => GetStream(args.FilePath).Result));
             };
 
             return this.completionSource.Task;
@@ -294,6 +291,17 @@ namespace Plugin.FilePicker
                 await this.SaveFile(fileToOpen);
                 this.OpenFile(fileToOpen);
             }
+        }
+
+        /// <summary>
+        /// Implementation for getting a stream of a file on iOS.
+        /// </summary>
+        /// <param name="filePath">
+        /// Specifies the file from which the stream should be opened.
+        /// <returns>stream object</returns>
+        public Task<Stream> GetStream(string filePath)
+        {
+            return Task.Run(() => (Stream)new FileStream(filePath, FileMode.Open, FileAccess.Read));
         }
     }
 }

--- a/src/Plugin.FilePicker/FilePickerImplementation.mac.cs
+++ b/src/Plugin.FilePicker/FilePickerImplementation.mac.cs
@@ -40,7 +40,7 @@ namespace Plugin.FilePicker
                 {
                     var path = url.Path;
                     var fileName = Path.GetFileName(path);
-                    data = new FileData(path, fileName, () => File.OpenRead(path));
+                    data = new FileData(path, fileName, () => GetStream(path).Result);
                 }
             }
 
@@ -116,6 +116,17 @@ namespace Plugin.FilePicker
             {
                 // ignore exceptions
             }
+        }
+
+        /// <summary>
+        /// Implementation for getting a stream of a file on mac.
+        /// </summary>
+        /// <param name="filePath">
+        /// Specifies the file from which the stream should be opened.
+        /// <returns>stream object</returns>
+        public Task<Stream> GetStream(string filePath)
+        {
+            return Task.Run(() => (Stream)File.OpenRead(filePath));
         }
     }
 }

--- a/src/Plugin.FilePicker/FilePickerImplementation.net45.cs
+++ b/src/Plugin.FilePicker/FilePickerImplementation.net45.cs
@@ -41,7 +41,7 @@ namespace Plugin.FilePicker
 
             var fileName = Path.GetFileName(picker.FileName);
 
-            var data = new FileData(picker.FileName, fileName, () => File.OpenRead(picker.FileName), (x) => { });
+            var data = new FileData(picker.FileName, fileName, () => GetStream(picker.FileName).Result, (x) => { });
 
             return Task.FromResult(data);
         }
@@ -109,6 +109,17 @@ namespace Plugin.FilePicker
             {
                 // ignore exception
             }
+        }
+
+        /// <summary>
+        /// Implementation for getting a stream of a file on net45.
+        /// </summary>
+        /// <param name="filePath">
+        /// Specifies the file from which the stream should be opened.
+        /// <returns>stream object</returns>
+        public Task<Stream> GetStream(string filePath)
+        {
+            return Task.Run(() => (Stream) File.OpenRead(filePath));
         }
     }
 }

--- a/src/Plugin.FilePicker/IFilePicker.shared.cs
+++ b/src/Plugin.FilePicker/IFilePicker.shared.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Plugin.FilePicker.Abstractions
@@ -29,6 +30,16 @@ namespace Plugin.FilePicker.Abstractions
         /// File data object, or null when user cancelled picking file
         /// </returns>
         Task<FileData> PickFile(string[] allowedTypes = null);
+
+        /// <summary>
+        /// Gets stream to access the file from the path.
+        /// Note that when DataArray property was already accessed, the stream
+        /// must be rewinded to the beginning.
+        /// </summary>
+        /// <param name="filePath">
+        /// Specifies the file from which the stream should be opened.
+        /// <returns>stream object</returns>
+        Task<Stream> GetStream(string filePath);
 
         /// <summary>
         /// Saves the file that was picked to external storage.


### PR DESCRIPTION
### Description of Change ###

I added a GetStream Mthod for each platform, so you could access the stream from a file a user picked later just from the file path.
It is usefull if you for example want to forward a file via the MessagingCenter, you now can forward the file path and access the stream via this method.

### Platforms Affected ### 
All Platforms


Unfortunately I couldn't test every platform because of weird errors in my VS.