### PR TITLE
Android: Overridable intent action property

### DIFF
--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -26,6 +26,11 @@ namespace Plugin.FilePicker
         public const string ExtraAllowedTypes = "EXTRA_ALLOWED_TYPES";
 
         /// <summary>
+        /// Intent Extra constant to pass intent action. Defaults to Intent.ActionGetContent
+        /// </summary>
+        public const string ExtraIntentAction = "EXTRA_INTENT_ACTION";
+
+        /// <summary>
         /// This variable gets passed when the request for the permission to access storage
         /// gets send and then gets again read whne the request gets answered.
         /// </summary>
@@ -98,7 +103,8 @@ namespace Plugin.FilePicker
         /// </summary>
         private void StartPicker()
         {
-            var intent = new Intent(Intent.ActionGetContent);
+            var intentAction = Intent.GetStringExtra(ExtraIntentAction) ?? Intent.ActionGetContent;
+            var intent = new Intent(intentAction);
 
             intent.SetType("*/*");
 

--- a/src/Plugin.FilePicker/Android/FilePickerImplementation.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerImplementation.android.cs
@@ -36,6 +36,11 @@ namespace Plugin.FilePicker
         private TaskCompletionSource<FileData> completionSource;
 
         /// <summary>
+        /// Overridable intent action used when launching the media picker
+        /// </summary>
+        protected string IntentAction => Intent.ActionGetContent;
+
+        /// <summary>
         /// Creates a new file picker implementation
         /// </summary>
         public FilePickerImplementation()
@@ -57,7 +62,7 @@ namespace Plugin.FilePicker
         /// </returns>
         public async Task<FileData> PickFile(string[] allowedTypes)
         {
-            var fileData = await this.PickFileAsync(allowedTypes, Intent.ActionGetContent);
+            var fileData = await this.PickFileAsync(allowedTypes, IntentAction);
 
             return fileData;
         }
@@ -86,6 +91,7 @@ namespace Plugin.FilePicker
                 pickerIntent.SetFlags(ActivityFlags.NewTask);
 
                 pickerIntent.PutExtra(FilePickerActivity.ExtraAllowedTypes, allowedTypes);
+                pickerIntent.PutExtra(FilePickerActivity.ExtraIntentAction, action);
 
                 this.context.StartActivity(pickerIntent);
 


### PR DESCRIPTION
Adding an overridable intent action property for the Android file picker implementation

### Description of Change ###

On some Android devices we see this error when attempting to pick a file:
`java.lang.SecurityException: Permission Denial: opening provider com.google.android.apps.docs.storagebackend.StorageBackendContentProvider from ProcessRecord{c8decebd0 6909:<package_name>/u0a206} (pid=6909, uid=10206) requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs`

So while `Intent.ActionGetContent` seems to work in most cases, `Intent.ActionOpenDocument` seems to work more consistently. Rather than change the intent action, this PR seeks to allow the user to subclass `FilePickerImplementation.android.cs` and override the intent action when they feel a different intent action might be more appropriate.

### Issues Resolved ### 

- fixes #172

### Platforms Affected ### 
- Android
