### PR TITLE
Get extension by MIME type

### DIFF
--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -5,6 +5,7 @@ using Android.Provider;
 using Android.Runtime;
 using Plugin.FilePicker.Abstractions;
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 using Android;
@@ -225,11 +226,18 @@ namespace Plugin.FilePicker
 
             if (!string.IsNullOrWhiteSpace(name))
             {
+                if (!Path.HasExtension(name))
+                    name = name.TrimEnd('.') + '.' + IOUtil.GetExtensionFromUri(context, uri);
+
                 return name;
             }
             else
             {
-                return System.IO.Path.GetFileName(WebUtility.UrlDecode(uri.ToString()));
+                var extension = IOUtil.GetExtensionFromUri(context, uri);
+                if (!string.IsNullOrEmpty(extension))
+                    return "filename." + extension;
+                else
+                    return Path.GetFileName(WebUtility.UrlDecode(uri.ToString()));
             }
         }
 

--- a/src/Plugin.FilePicker/Android/IOUtil.android.cs
+++ b/src/Plugin.FilePicker/Android/IOUtil.android.cs
@@ -230,5 +230,17 @@ namespace Plugin.FilePicker
 
             return type;
         }
+
+        /// <summary>
+        /// Returns a file extension for given content Uri
+        /// </summary>
+        /// <param name="context">context to use</param>
+        /// <param name="uri">content Uri to check</param>
+        /// <returns>file extension, without leading dot, or empty string</returns>
+        public static string GetExtensionFromUri(Context context, Android.Net.Uri uri)
+        {
+            string mimeType = context.ContentResolver.GetType(uri);
+            return mimeType != null ? MimeTypeMap.Singleton.GetExtensionFromMimeType(mimeType) : string.Empty;
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###

On Android, when the FileName property is empty, the code tries to get the file extension by MIME type and returns "filename.ext".

### Issues Resolved ### 

- fixes #130

### Platforms Affected ### 

- Android