### PR TITLE
Android uri lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 2.1.xx
+
+Android: When a `content://` URI is returned for a picked file, the plugin now
+tries to keep permissions to the picked content (#172, #158).
+
 ## Version 2.1.34
 
 (Re-)added SourceLink support

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ you access it via GetStream() afterwards.
 
 ### **IMPORTANT**
 **Android:**
+The FilePath property may contain a content URI that starts with `content://`.
+The plugin tries hard to find out an actual filename, but when it can't, the
+file can only be accessed using `GetStream()` or `DataArray`. On Android
+`ContentProvider` classes are used to share data between apps. The resource
+that is accessed may not even be a file, streamed over the internet or loaded
+from a database.
+
+The plugin also tries to get a persistable content URI that can be stored for
+later access. Be prepared that this may fail, though. Content could have been
+moved to a different location or could be deleted.
+
 The `READ_EXTERNAL_STORAGE` permission is automatically added to your Android
 app project. Starting from Android 6.0 (Marshmallow) the user is asked for the
 permission when not granted yet. When the user denies the permission,

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -98,7 +98,8 @@ namespace Plugin.FilePicker
         /// </summary>
         private void StartPicker()
         {
-            var intent = new Intent(Intent.ActionGetContent);
+            var intent = new Intent(
+                Build.VERSION.SdkInt < BuildVersionCodes.Kitkat ? Intent.ActionGetContent : Intent.ActionOpenDocument);
 
             intent.SetType("*/*");
 
@@ -110,7 +111,11 @@ namespace Plugin.FilePicker
                 intent.PutExtra(Intent.ExtraMimeTypes, allowedTypes);
             }
 
-            intent.AddCategory(Intent.CategoryOpenable);
+            if (Build.VERSION.SdkInt < BuildVersionCodes.Kitkat)
+            {
+                intent.AddCategory(Intent.CategoryOpenable);
+            }
+
             try
             {
                 this.StartActivityForResult(Intent.CreateChooser(intent, "Select file"), 0);

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -115,6 +115,10 @@ namespace Plugin.FilePicker
             {
                 intent.AddCategory(Intent.CategoryOpenable);
             }
+            else
+            {
+                intent.AddFlags(ActivityFlags.GrantPersistableUriPermission);
+            }
 
             try
             {
@@ -152,6 +156,13 @@ namespace Plugin.FilePicker
                     System.Diagnostics.Debug.Write(data.Data);
 
                     var uri = data.Data;
+
+                    if (Build.VERSION.SdkInt >= BuildVersionCodes.Kitkat)
+                    {
+                        context.ContentResolver.TakePersistableUriPermission(
+                            uri,
+                            ActivityFlags.GrantReadUriPermission);
+                    }
 
                     var filePath = IOUtil.GetPath(this.context, uri);
 


### PR DESCRIPTION
### Description of Change ###

These changes should fix some people's problems to use picked content:// URIs that are stored in the meantime and can't be used later. The changes use ACTION_OPEN_DOCUMENT on Android 4.4 (KitKat) or higher, and TakePersistableUriPermission() is called after picking to keep permissions to access the content:// URIs.

I debugged the code with the sample app and picking made no difference in UI, and it didn't crash. The patch should maybe go into a beta build so that people can try out the change before publishing a release NuGet package.

@championofblocks This PR is a variation of #173, where the ACTION_OPEN_DOCUMENT intent is made configurable. Since the PR modifies the public API of the public, the change may still go into a 2.2-beta release at some point in time.

### Issues Resolved ### 

- fixes #172, #158

### Platforms Affected ### 

- Android
