### PR TITLE
Add support for dotnet core > 3.0, dotnet 46, 47, 48

### DIFF
--- a/samples/Plugin.FilePicker.Sample.Forms.sln
+++ b/samples/Plugin.FilePicker.Sample.Forms.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.FilePicker.Sample.Forms", "Plugin.FilePicker.Sample.Forms\Forms\Plugin.FilePicker.Sample.Forms.csproj", "{BC539575-3B77-4A4A-8F3A-2203BB590674}"
 EndProject
@@ -22,6 +22,18 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Sample.Forms.WPF", "Plugin.FilePicker.Sample.Forms\WPF\Plugin.FilePicker.Sample.Forms.WPF.csproj", "{66178C86-2063-4A5A-89A1-5005F3FAE5A4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.FilePicker", "..\src\Plugin.FilePicker\Plugin.FilePicker.csproj", "{507FA967-A579-44FE-9CA3-7CEE18B5257B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Sample.Wpf.Framework4.6", "Plugin.FilePicker.Sample.Wpf\Framework\Plugin.FilePicker.Sample.Wpf.Framework4.6.csproj", "{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Sample.Wpf.Framework4.7", "Plugin.FilePicker.Sample.Wpf\Framework\Plugin.FilePicker.Sample.Wpf.Framework4.7.csproj", "{CED9B20C-89E8-4802-99C4-174F661DFE48}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Sample.Wpf.Framework4.8", "Plugin.FilePicker.Sample.Wpf\Framework\Plugin.FilePicker.Sample.Wpf.Framework4.8.csproj", "{79F11D65-DF0E-44B1-BE64-045DC333A44E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.FilePicker.Sample.Wpf.Framework4.5", "Plugin.FilePicker.Sample.Wpf\Framework\Plugin.FilePicker.Sample.Wpf.Framework4.5.csproj", "{7144A2C0-C49B-4285-9213-82194AB23F5F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.FilePicker.Sample.Wpf.Core3.0", "Plugin.FilePicker.Sample.Wpf\Core3.0\Plugin.FilePicker.Sample.Wpf.Core3.0.csproj", "{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Plugin.FilePicker.Sample.Wpf.Core3.1", "Plugin.FilePicker.Sample.Wpf\Core3.1\Plugin.FilePicker.Sample.Wpf.Core3.1.csproj", "{968ED80E-DFAB-4051-875A-24DD08A833B9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -189,6 +201,150 @@ Global
 		{507FA967-A579-44FE-9CA3-7CEE18B5257B}.Release|x64.Build.0 = Release|Any CPU
 		{507FA967-A579-44FE-9CA3-7CEE18B5257B}.Release|x86.ActiveCfg = Release|Any CPU
 		{507FA967-A579-44FE-9CA3-7CEE18B5257B}.Release|x86.Build.0 = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|x64.Build.0 = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Debug|x86.Build.0 = Debug|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|ARM.Build.0 = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|iPhone.Build.0 = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|x64.ActiveCfg = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|x64.Build.0 = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|x86.ActiveCfg = Release|Any CPU
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C}.Release|x86.Build.0 = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|ARM.Build.0 = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|x64.Build.0 = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Debug|x86.Build.0 = Debug|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|ARM.ActiveCfg = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|ARM.Build.0 = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|iPhone.Build.0 = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|x64.ActiveCfg = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|x64.Build.0 = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|x86.ActiveCfg = Release|Any CPU
+		{CED9B20C-89E8-4802-99C4-174F661DFE48}.Release|x86.Build.0 = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|ARM.Build.0 = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|x64.Build.0 = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Debug|x86.Build.0 = Debug|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|ARM.ActiveCfg = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|ARM.Build.0 = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|iPhone.Build.0 = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|x64.ActiveCfg = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|x64.Build.0 = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|x86.ActiveCfg = Release|Any CPU
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E}.Release|x86.Build.0 = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|x64.Build.0 = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Debug|x86.Build.0 = Debug|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|ARM.Build.0 = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|iPhone.Build.0 = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|x64.ActiveCfg = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|x64.Build.0 = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{7144A2C0-C49B-4285-9213-82194AB23F5F}.Release|x86.Build.0 = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|x64.Build.0 = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Debug|x86.Build.0 = Debug|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|ARM.Build.0 = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|iPhone.Build.0 = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|x64.ActiveCfg = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|x64.Build.0 = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|x86.ActiveCfg = Release|Any CPU
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211}.Release|x86.Build.0 = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|ARM.Build.0 = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|x64.Build.0 = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Debug|x86.Build.0 = Debug|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|ARM.ActiveCfg = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|ARM.Build.0 = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|iPhone.Build.0 = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|x64.ActiveCfg = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|x64.Build.0 = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|x86.ActiveCfg = Release|Any CPU
+		{968ED80E-DFAB-4051-875A-24DD08A833B9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -200,6 +356,12 @@ Global
 		{0F751E6D-BF0E-4BEE-AD43-4DA1AABB5211} = {5317C143-367E-4704-9DE5-6BAD007691AE}
 		{66178C86-2063-4A5A-89A1-5005F3FAE5A4} = {5317C143-367E-4704-9DE5-6BAD007691AE}
 		{507FA967-A579-44FE-9CA3-7CEE18B5257B} = {45FC3352-5F40-44CE-85C0-4A833A9761AA}
+		{3DC1A6AA-532C-493D-884D-94B5A2E94D5C} = {5317C143-367E-4704-9DE5-6BAD007691AE}
+		{CED9B20C-89E8-4802-99C4-174F661DFE48} = {5317C143-367E-4704-9DE5-6BAD007691AE}
+		{79F11D65-DF0E-44B1-BE64-045DC333A44E} = {5317C143-367E-4704-9DE5-6BAD007691AE}
+		{7144A2C0-C49B-4285-9213-82194AB23F5F} = {5317C143-367E-4704-9DE5-6BAD007691AE}
+		{C158FD3C-FCF5-48A7-ABEA-BA59473DC211} = {5317C143-367E-4704-9DE5-6BAD007691AE}
+		{968ED80E-DFAB-4051-875A-24DD08A833B9} = {5317C143-367E-4704-9DE5-6BAD007691AE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {82DDDDFC-CB44-4AF2-ACB4-9F4EFDC75198}

--- a/samples/Plugin.FilePicker.Sample.Wpf/App.xaml
+++ b/samples/Plugin.FilePicker.Sample.Wpf/App.xaml
@@ -1,0 +1,5 @@
+﻿<Application x:Class="Plugin.FilePicker.Sample.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/samples/Plugin.FilePicker.Sample.Wpf/App.xaml.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/App.xaml.cs
@@ -1,0 +1,6 @@
+﻿namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class App 
+    {
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Core3.0/AssemblyInfo.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Core3.0/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, 
+    ResourceDictionaryLocation.SourceAssembly
+)]

--- a/samples/Plugin.FilePicker.Sample.Wpf/Core3.0/MainWindow.3.0.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Core3.0/MainWindow.3.0.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class MainWindow
+    {
+        public string TargetFramework => "dotnet core 3.0";
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Core3.0/Plugin.FilePicker.Sample.Wpf.Core3.0.csproj
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Core3.0/Plugin.FilePicker.Sample.Wpf.Core3.0.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RootNamespace>Plugin.FilePicker.Sample.Wpf</RootNamespace>
+    <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\App.xaml.cs" Link="App.xaml.cs" />
+    <Compile Include="..\MainWindow.xaml.cs" Link="MainWindow.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindow.3.0.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ApplicationDefinition Include="..\App.xaml" Link="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
+    <Page Include="..\MainWindow.xaml" Link="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugin.FilePicker\Plugin.FilePicker.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Plugin.FilePicker.Sample.Wpf/Core3.1/AssemblyInfo.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Core3.1/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, 
+    ResourceDictionaryLocation.SourceAssembly
+)]

--- a/samples/Plugin.FilePicker.Sample.Wpf/Core3.1/MainWindow.3.1.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Core3.1/MainWindow.3.1.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class MainWindow
+    {
+        public string TargetFramework => "dotnet core 3.1";
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Core3.1/Plugin.FilePicker.Sample.Wpf.Core3.1.csproj
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Core3.1/Plugin.FilePicker.Sample.Wpf.Core3.1.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>Plugin.FilePicker.Sample.Wpf</RootNamespace>
+    <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\App.xaml.cs" Link="App.xaml.cs" />
+    <Compile Include="..\MainWindow.xaml.cs" Link="MainWindow.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindow.3.1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ApplicationDefinition Include="..\App.xaml" Link="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
+    <Page Include="..\MainWindow.xaml" Link="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugin.FilePicker\Plugin.FilePicker.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.5.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.5.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class MainWindow
+    {
+        public string TargetFramework => "dotnet framework 4.5";
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.6.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.6.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class MainWindow
+    {
+        public string TargetFramework => "dotnet framework 4.6";
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.7.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.7.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class MainWindow
+    {
+        public string TargetFramework => "dotnet framework 4.7";
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.8.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/MainWindow.4.8.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    public partial class MainWindow
+    {
+        public string TargetFramework => "dotnet framework 4.8";
+    }
+}

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.5.csproj
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.5.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Plugin.FilePicker.Sample.Wpf</RootNamespace>
+    <AssemblyName>Plugin.FilePicker.Sample.Wpf.Framework4.5</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <BaseIntermediateOutputPath>obj\4_5</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindow.4.5.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\App.xaml.cs" Link="App.xaml.cs" />
+    <Compile Include="..\MainWindow.xaml.cs" Link="MainWindow.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="..\App.xaml" Link="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
+    <Page Include="..\MainWindow.xaml" Link="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugin.FilePicker\Plugin.FilePicker.csproj">
+      <Project>{507fa967-a579-44fe-9ca3-7cee18b5257b}</Project>
+      <Name>Plugin.FilePicker</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.6.csproj
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.6.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Plugin.FilePicker.Sample.Wpf</RootNamespace>
+    <AssemblyName>Plugin.FilePicker.Sample.Wpf.Framework4.6</AssemblyName>
+    <BaseIntermediateOutputPath>obj\4_6</BaseIntermediateOutputPath>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindow.4.6.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\App.xaml.cs" Link="App.xaml.cs" />
+    <Compile Include="..\MainWindow.xaml.cs" Link="MainWindow.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="..\App.xaml" Link="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
+    <Page Include="..\MainWindow.xaml" Link="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugin.FilePicker\Plugin.FilePicker.csproj">
+      <Project>{507fa967-a579-44fe-9ca3-7cee18b5257b}</Project>
+      <Name>Plugin.FilePicker</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.7.csproj
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.7.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Plugin.FilePicker.Sample.Wpf</RootNamespace>
+    <AssemblyName>Plugin.FilePicker.Sample.Wpf.Framework4.7</AssemblyName>
+    <BaseIntermediateOutputPath>obj\4_7</BaseIntermediateOutputPath>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindow.4.7.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\App.xaml.cs" Link="App.xaml.cs" />
+    <Compile Include="..\MainWindow.xaml.cs" Link="MainWindow.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="..\App.xaml" Link="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
+    <Page Include="..\MainWindow.xaml" Link="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugin.FilePicker\Plugin.FilePicker.csproj">
+      <Project>{507fa967-a579-44fe-9ca3-7cee18b5257b}</Project>
+      <Name>Plugin.FilePicker</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.8.csproj
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/Plugin.FilePicker.Sample.Wpf.Framework4.8.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Plugin.FilePicker.Sample.Wpf</RootNamespace>
+    <AssemblyName>Plugin.FilePicker.Sample.Wpf.Framework4.8</AssemblyName>
+    <BaseIntermediateOutputPath>obj\4_8</BaseIntermediateOutputPath>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindow.4.8.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\App.xaml.cs" Link="App.xaml.cs" />
+    <Compile Include="..\MainWindow.xaml.cs" Link="MainWindow.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="..\App.xaml" Link="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </ApplicationDefinition>
+    <Page Include="..\MainWindow.xaml" Link="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Plugin.FilePicker\Plugin.FilePicker.csproj">
+      <Project>{507fa967-a579-44fe-9ca3-7cee18b5257b}</Project>
+      <Name>Plugin.FilePicker</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/samples/Plugin.FilePicker.Sample.Wpf/Framework/Properties/AssemblyInfo.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/Framework/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None,
+    ResourceDictionaryLocation.SourceAssembly
+)]

--- a/samples/Plugin.FilePicker.Sample.Wpf/MainWindow.xaml
+++ b/samples/Plugin.FilePicker.Sample.Wpf/MainWindow.xaml
@@ -1,0 +1,29 @@
+﻿<Window x:Class="Plugin.FilePicker.Sample.Wpf.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <Grid.Resources>
+            <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                <Setter Property="Margin" Value="20"/>
+                <Setter Property="FontSize" Value="36" />
+                <Setter Property="TextWrapping" Value="WrapWithOverflow" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+            </Style>
+        </Grid.Resources>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <TextBlock Grid.Column="1" Text="{Binding TargetFramework}"/>
+        <TextBlock Grid.Row="1" Text="you selected:"/>
+        <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding File}"/>
+    </Grid>
+</Window>

--- a/samples/Plugin.FilePicker.Sample.Wpf/MainWindow.xaml.cs
+++ b/samples/Plugin.FilePicker.Sample.Wpf/MainWindow.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+
+namespace Plugin.FilePicker.Sample.Wpf
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : Window, INotifyPropertyChanged
+    {
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public string File { get; set; }
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            Loaded += MainWindow_Loaded;
+            DataContext = this;
+        }
+
+        private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            var data = await FilePicker.CrossFilePicker.Current.PickFile();
+            File = data.FilePath;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("File"));
+        }
+    }
+}

--- a/src/Plugin.FilePicker/Plugin.FilePicker.csproj
+++ b/src/Plugin.FilePicker/Plugin.FilePicker.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80;MonoAndroid81;MonoAndroid90;MonoAndroid10.0;Xamarin.Mac20;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;Xamarin.iOS10;MonoAndroid80;MonoAndroid81;MonoAndroid90;MonoAndroid10.0;Xamarin.Mac20;netcoreapp3.0;netcoreapp3.1;net45;net46;net47;net48</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);uap10.0.16299</TargetFrameworks>
     <AssemblyName>Plugin.FilePicker</AssemblyName>
     <RootNamespace>Plugin.FilePicker</RootNamespace>
@@ -71,12 +71,20 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3')) ">
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="**\*.shared.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <Compile Include="**\*.netstandard.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3')) ">
+    <Compile Include="**\*.net45.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap10.0')) ">
@@ -95,7 +103,7 @@
     <Compile Include="**\*.mac.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net45')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Compile Include="**\*.net45.cs" />
     <Reference Include="PresentationFramework" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Create support for dotnetcore

<!-- Describe your changes here. -->

Add dotnetcore target frameworks, and link them to dotnet 45 sources

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #186 Not working on Windows 10 IoT Core
- fixes #153 Plugin not Working with wpf (.Net Core 3.0)

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- dotnetcore 3.0
- dotnetcore 3.1
- dotnet 4.6
- dotnet 4.7
- dotnet 4.8
