### PR TITLE
If FilePickerActivity was killed by the system, it should not present the picker again

### DIFF
--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -50,6 +50,9 @@ namespace Plugin.FilePicker
 
             this.context = Application.Context;
 
+            if (savedInstanceState != null)
+                return;
+                
             if (this.context.PackageManager.CheckPermission(
                 Manifest.Permission.ReadExternalStorage,
                 this.context.PackageName) == Permission.Granted)

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -50,6 +50,8 @@ namespace Plugin.FilePicker
 
             this.context = Application.Context;
 
+            /*If OnCreate is called with savedInstanceState, it's an attempt to restore the activity after it was killed by the system,
+            but the picker has already been presented before and we don't want to present it again. Reproducible with DKA.*/
             if (savedInstanceState != null)
                 return;
                 


### PR DESCRIPTION
### Description of Change ###

When you turn on `Don't keep activities` in Android Developer options (or are using a device with low memory) and try to pick a file, it shows the picker again right after picking the file, because the FilePickerActivity is restored when you get back from the picker intent and calls `StartPicker()` again.

This fixes the issue and picking files works even with `DKA`.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android
