### PR TITLE
Added condition to stop path conversion on android

### DIFF
--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -170,9 +170,15 @@ namespace Plugin.FilePicker
                             ActivityFlags.GrantReadUriPermission);
                     }
 
-                    var filePath = IOUtil.GetPath(this.context, uri);
+                    // The scoped storage feature was introduced on Android Q and it prevents direct file access on external storage. 
+                    // Thus, using the IOUtil.GetPath should be avoided because a System.UnauthorizedAccessException
+                    // will be thrown when calling File.OpenRead() on the local path.
+                    // For more information, see: https://developer.android.com/training/data-storage/#scoped-storage
+                    var filePath = (int)Build.VERSION.SdkInt >= 29
+                        ? uri.ToString()
+                        : IOUtil.GetPath(this.context, uri);
 
-                    if ((int)Build.VERSION.SdkInt >= 29 || string.IsNullOrEmpty(filePath))
+                    if (string.IsNullOrEmpty(filePath))
                     {
                         filePath = IOUtil.IsMediaStore(uri.Scheme) ? uri.ToString() : uri.Path;
                     }

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -170,7 +170,9 @@ namespace Plugin.FilePicker
                             ActivityFlags.GrantReadUriPermission);
                     }
 
-                    var filePath = IOUtil.GetPath(this.context, uri);
+                    var filePath = Build.VERSION.SdkInt >= BuildVersionCodes.Q
+                        ? uri.ToString()
+                        : IOUtil.GetPath(this.context, uri);
 
                     if (string.IsNullOrEmpty(filePath))
                     {

--- a/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
+++ b/src/Plugin.FilePicker/Android/FilePickerActivity.android.cs
@@ -170,11 +170,9 @@ namespace Plugin.FilePicker
                             ActivityFlags.GrantReadUriPermission);
                     }
 
-                    var filePath = Build.VERSION.SdkInt >= BuildVersionCodes.Q
-                        ? uri.ToString()
-                        : IOUtil.GetPath(this.context, uri);
+                    var filePath = IOUtil.GetPath(this.context, uri);
 
-                    if (string.IsNullOrEmpty(filePath))
+                    if ((int)Build.VERSION.SdkInt >= 29 || string.IsNullOrEmpty(filePath))
                     {
                         filePath = IOUtil.IsMediaStore(uri.Scheme) ? uri.ToString() : uri.Path;
                     }


### PR DESCRIPTION
### Description of Change ###
On Android Q (10) the File Path returned on a file pick may refer to an external location like the Downloads folder. Upon trying to read the file, a System.UnauthorizedAccessException is thrown. This change will use the original content URI and content resolver to load the file instead of File.OpenRead.

### Issues Resolved ### 
- fixes #184

### Platforms Affected ### 
- Android