### PR TITLE
Fix ios implementation leading to crashes.

### DIFF
--- a/samples/Plugin.FilePicker.Sample.Forms.sln
+++ b/samples/Plugin.FilePicker.Sample.Forms.sln
@@ -80,6 +80,7 @@ Global
 		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|ARM.ActiveCfg = Debug|iPhone
 		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|iPhone.Build.0 = Debug|iPhone
+		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|iPhone.Deploy.0 = Debug|iPhone
 		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{32F6F5E8-CD92-40E5-B088-2C5D258AB9DE}.Debug|x64.ActiveCfg = Debug|iPhone


### PR DESCRIPTION
### Description of Change ###
I changed how the TaskCompletionSource is handled, so it can not crash in any situation.

### Issues Resolved ### 
For example when 2 items are selected, it was nulled twice, even if the picker supports only 1 selection at a time!

- fixes #196 

Tested on a real iOS device.

### Platforms Affected ### 

- iOS
