### PR TITLE
Set ModalPresentationStyle to FullScreen to prevent iOS 14 swipe down…

### DIFF
--- a/src/Plugin.FilePicker/FilePickerImplementation.ios.cs
+++ b/src/Plugin.FilePicker/FilePickerImplementation.ios.cs
@@ -154,7 +154,7 @@ namespace Plugin.FilePicker
             // while opening (UIDocumentPickerMode.Open) opens the document directly. We do the
             // first, so the user has to read the file immediately.
             var documentPicker = new UIDocumentPickerViewController(allowedUtis, UIDocumentPickerMode.Import);
-
+            documentPicker.ModalPresentationStyle = UIModalPresentationStyle.FullScreen;
             documentPicker.DidPickDocument += this.DocumentPicker_DidPickDocument;
             documentPicker.WasCancelled += this.DocumentPicker_WasCancelled;
             documentPicker.DidPickDocumentAtUrls += this.DocumentPicker_DidPickDocumentAtUrls;


### PR DESCRIPTION
… dismissal

### Description of Change ###
On iOS 13 and above the filepicker appears as a modal view. On iOS 14 in particular you are able to swipe down to dismiss the modal, which for some reason doesn't trigger the WasCancelled event. In my application this causes an error and prevents me from relaunching the filepicker without restarting the application.

Setting the modal presentation style to FullScreen prevents this issue.

### Issues Resolved ### 
 - None

### Platforms Affected ### 
- iOS

